### PR TITLE
exporting all types from pure as well

### DIFF
--- a/pure.d.ts
+++ b/pure.d.ts
@@ -1,3 +1,11 @@
 import {loadStripeTerminal as IloadStripeTerminal} from './src/pure';
+import {TerminalProps} from './types/terminal-js/rabbit/terminal-props';
+import {Terminal} from './types/terminal-js/index';
+
+export * from './types/terminal-js/index';
+
+export interface StripeTerminal {
+  create(props: TerminalProps): Terminal;
+}
 
 export const loadStripeTerminal: typeof IloadStripeTerminal;


### PR DESCRIPTION
### Summary & motivation
While working with the `pure` version of the app it became apparent we don't export types here. Given that the default import will start auto-loading the sdk users cannot default to using that to get their types without some needless misdirection. As such exporting the types from pure as well so this is more useful.
<!-- Simple summary of what the code does or what you have changed. -->

context: the `pure` import is a version of the import that doesn't auto-load the sdk on require, deferring until the user has explicitly called `loadStripeTerminal()`

### Testing & documentation
CI passes, 🚢 
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
