### PR TITLE
restoring enum exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,6 @@ Note that we may release new [minor and patch](https://semver.org/) versions of
 `@stripe/terminal-js` with small but backwards-incompatible fixes to the type
 declarations. These changes will not affect the Terminal JS SDK itself.
 
-## A note on enum behavior
-
-Due to the fact that only types and not runtime is directly exported by the lib,
-enums exported by `@stripe/terminal-js` will unfortunately export as
-`undefined`. However, these enums are still available on the `StripeTerminal`
-placed on `window` (i.e. `window.StripeTerminal.PaymentStatus.READY`).
-
 ## Ensuring the Terminal JS SDK is available everywhere
 
 By default, this module will insert a `<script>` tag that loads the Terminal JS

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Note that we may release new [minor and patch](https://semver.org/) versions of
 `@stripe/terminal-js` with small but backwards-incompatible fixes to the type
 declarations. These changes will not affect the Terminal JS SDK itself.
 
+## A note on enum behavior
+
+Due to the fact that only types and not runtime is directly exported by the lib,
+enums exported by `@stripe/terminal-js` will unfortunately export as
+`undefined`. However, these enums are still available on the `StripeTerminal`
+placed on `window` (i.e. `window.StripeTerminal.PaymentStatus.READY`).
+
 ## Ensuring the Terminal JS SDK is available everywhere
 
 By default, this module will insert a `<script>` tag that loads the Terminal JS

--- a/pure.d.ts
+++ b/pure.d.ts
@@ -1,11 +1,17 @@
 import {loadStripeTerminal as IloadStripeTerminal} from './src/pure';
 import {TerminalProps} from './types/terminal-js/rabbit/terminal-props';
-import {Terminal} from './types/terminal-js/index';
+import {
+  Terminal,
+  PaymentStatus,
+  ConnectionStatus,
+} from './types/terminal-js/index';
 
 export * from './types/terminal-js/index';
 
 export interface StripeTerminal {
   create(props: TerminalProps): Terminal;
+  PaymentStatus: PaymentStatus;
+  ConnectionStatus: ConnectionStatus;
 }
 
 export const loadStripeTerminal: typeof IloadStripeTerminal;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,16 @@
-import {Terminal, TerminalProps} from './terminal';
+import {
+  Terminal,
+  TerminalProps,
+  PaymentStatus,
+  ConnectionStatus,
+} from './terminal';
 
 export * from './terminal';
 
 export interface StripeTerminal {
   create(props: TerminalProps): Terminal;
+  PaymentStatus: PaymentStatus;
+  ConnectionStatus: ConnectionStatus;
 }
 
 export const loadStripeTerminal: () => Promise<StripeTerminal | null>;

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -51,15 +51,19 @@ export interface TerminalOptions {
 export declare type TerminalProps = TerminalOptions & TerminalCallbacks;
 
 export declare type PaymentIntentClientSecret = string;
-export declare type PaymentStatus =
-  | 'not_ready'
-  | 'ready'
-  | 'waiting_for_input'
-  | 'processing';
-export declare type ConnectionStatus =
-  | 'connecting'
-  | 'connected'
-  | 'not_connected';
+
+export enum PaymentStatus {
+  NOT_READY = 'not_ready',
+  READY = 'ready',
+  WAITING_FOR_INPUT = 'waiting_for_input',
+  PROCESSING = 'processing',
+}
+
+export enum ConnectionStatus {
+  CONNECTING = 'connecting',
+  CONNECTED = 'connected',
+  NOT_CONNECTED = 'not_connected',
+}
 
 // eslint-disable-next-line
 export interface ISdkManagedPaymentIntent extends IPaymentIntent {

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -18,6 +18,19 @@ export {
   ITipConfiguration,
 };
 
+export enum PaymentStatus {
+  NOT_READY = 'not_ready',
+  READY = 'ready',
+  WAITING_FOR_INPUT = 'waiting_for_input',
+  PROCESSING = 'processing',
+}
+
+export enum ConnectionStatus {
+  CONNECTING = 'connecting',
+  CONNECTED = 'connected',
+  NOT_CONNECTED = 'not_connected',
+}
+
 export declare type ConnectionToken = string;
 export declare type FetchConnectionTokenFn = () => Promise<ConnectionToken>;
 
@@ -51,19 +64,6 @@ export interface TerminalOptions {
 export declare type TerminalProps = TerminalOptions & TerminalCallbacks;
 
 export declare type PaymentIntentClientSecret = string;
-
-export enum PaymentStatus {
-  NOT_READY = 'not_ready',
-  READY = 'ready',
-  WAITING_FOR_INPUT = 'waiting_for_input',
-  PROCESSING = 'processing',
-}
-
-export enum ConnectionStatus {
-  CONNECTING = 'connecting',
-  CONNECTED = 'connected',
-  NOT_CONNECTED = 'not_connected',
-}
 
 // eslint-disable-next-line
 export interface ISdkManagedPaymentIntent extends IPaymentIntent {


### PR DESCRIPTION
### Summary & motivation
Restoring our enum types due to a regression in some integrations caused by the move to unions. Guidance is now provided in the readme on how users can still go about accessing enum values from the `StripeTerminal` object

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
CI passes, docs updated, 🚢 

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
