### PR TITLE
Replacing `any` types in readReusableCard and refund repsonses

### DIFF
--- a/types/proto.d.ts
+++ b/types/proto.d.ts
@@ -131,6 +131,46 @@ export interface IPaymentMethod {
   /** Tip selection chosen by the cardholder */
   tip_selection?: ITipSelection | null;
 }
+
+/** Properties of a PaymentMethod. */
+export interface IPaymentMethodReadReusableResponse {
+  /** Unique identifier for the Payment Method object */
+  id?: string | null;
+
+  /** Time at which the Payment Method object was created. Measured in seconds since the Unix epoch */
+  created?: number | null;
+
+  /** Customer ID */
+  customer?: string | null;
+
+  /** Whether this charge was made in live mode or not */
+  livemode?: boolean | null;
+
+  /** Meta data in JSON format */
+  metadata?: {[k: string]: string} | null;
+
+  /** PaymentMethod type */
+  type?: string | null;
+
+  /** Card representation of payment method */
+  card?: ICardPaymentMethodReadReusableResponse | null;
+}
+
+/** Properties of a CardPaymentMethod. */
+interface ICardPaymentMethodReadReusableResponse {
+  /** Masked card data */
+  masked_pan?: string | null;
+
+  /** The card expiration date */
+  expiration_date?: string | null;
+
+  /** Brand of credit card tender, determined by BIN table lookup */
+  card_brand?: CreditCardBrand | null;
+
+  /** Entry method of payment */
+  card_entry_method?: CardEntryMethod | null;
+}
+
 /** Properties of an ErrorResponse. */
 export interface IErrorResponse {
   /** The type of error returned. */

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -3,19 +3,23 @@ import {
   IErrorResponse,
   IPaymentIntent,
   IPaymentMethod,
+  IPaymentMethodReadReusableResponse,
   IRefundChargeRequest,
   ISetReaderDisplayRequest,
   ITipConfiguration,
+  IRefund,
 } from './proto';
 
 export {
   IActivateTerminalRequest,
   IErrorResponse,
   IPaymentIntent,
+  IPaymentMethodReadReusableResponse,
   IPaymentMethod,
   IRefundChargeRequest,
   ISetReaderDisplayRequest,
   ITipConfiguration,
+  IRefund,
 };
 
 export enum PaymentStatus {
@@ -211,7 +215,7 @@ export class Terminal {
   }): Promise<
     | ErrorResponse
     | {
-        payment_method: any;
+        payment_method: IPaymentMethodReadReusableResponse;
       }
   >;
   collectRefundPaymentMethod(
@@ -224,7 +228,7 @@ export class Terminal {
     | ErrorResponse
     | ErrorResponse
     | {
-        refund: any;
+        refund: IRefund;
       }
   >;
   cancelCollectRefundPaymentMethod(): Promise<ErrorResponse | {}>;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Updating the response types in our public API that were previously denoted with `any`

### Testing & documentation
Validated on our internal merchant app, only change required was checking the existence of `id` on `payment_method` as it is officially marked as nullable.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
