### PR TITLE
Add testPaymentMethod and testCardNumber to SimulatorConfiguration

### DIFF
--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -100,6 +100,8 @@ export declare type ExposedError = {
 
 export interface SimulatorConfiguration {
   paymentMethodType?: 'interac_present' | null;
+  testPaymentMethod?: string | null;
+  testCardNumber?: string | null;
 }
 
 export interface Reader {


### PR DESCRIPTION
### Summary & motivation

Updating the `SimulatorConfiguration` interface to support the new `testPaymentMethod` and `testCardNumber` attributes.

### Testing & documentation

Tested in internal webpos project and created an internal PR to update public-facing documentation.
