### PR TITLE
Fix PCI compliance guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ module.
 
 **Note**: This package dynamically loads the Stripe Terminal SDK from
 `https://js.stripe.com` and wraps the SDK's global`StripeTerminal` function. To
-be [PCI compliant](https://stripe.com/docs/security#validating-pci-compliance),
+be
+[PCI compliant](https://stripe.com/docs/security/guide#validating-pci-compliance),
 you must load the SDK directly from `https://js.stripe.com` by using this
 library. You cannot include the dynamically loaded code in a bundle or host it
 yourself.


### PR DESCRIPTION
### Summary & motivation

Updated a slightly broken link in the README to the PCI compliance section of the security guide. Same change as in https://github.com/stripe/stripe-js/pull/75.