### PR TITLE
Fix check for hub command existence in publish script

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -17,7 +17,8 @@ EOF
 }
 
 create_github_release() {
-  if which hub | grep -q "not found"; then
+  if ! command -v hub &> /dev/null
+  then
     create_github_release_fallback
     return
   fi


### PR DESCRIPTION
### Summary & motivation

This would fail with the following error if hub was not installed:

`./scripts/publish: line 57: hub: command not found`

### Testing & documentation

Simple bash conditional change, tested manually in my dev environment