### PR TITLE
Adding output log level to type list

### DIFF
--- a/pure.d.ts
+++ b/pure.d.ts
@@ -4,6 +4,7 @@ import {
   Terminal,
   PaymentStatus,
   ConnectionStatus,
+  OutputLogLevel,
 } from './types/terminal-js/index';
 
 export * from './types/terminal-js/index';
@@ -12,6 +13,7 @@ export interface StripeTerminal {
   create(props: TerminalProps): Terminal;
   PaymentStatus: PaymentStatus;
   ConnectionStatus: ConnectionStatus;
+  OutputLogLevel: OutputLogLevel;
 }
 
 export const loadStripeTerminal: typeof IloadStripeTerminal;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,7 @@ import {
   TerminalProps,
   PaymentStatus,
   ConnectionStatus,
+  OutputLogLevel,
 } from './terminal';
 
 export * from './terminal';
@@ -11,6 +12,7 @@ export interface StripeTerminal {
   create(props: TerminalProps): Terminal;
   PaymentStatus: PaymentStatus;
   ConnectionStatus: ConnectionStatus;
+  OutputLogLevel: OutputLogLevel;
 }
 
 export const loadStripeTerminal: () => Promise<StripeTerminal | null>;

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -35,13 +35,14 @@ export enum ConnectionStatus {
   NOT_CONNECTED = 'not_connected',
 }
 
-export declare type ConnectionToken = string;
-export declare type FetchConnectionTokenFn = () => Promise<ConnectionToken>;
-
-export declare enum OutputLogLevel {
+export enum OutputLogLevel {
   NONE = 'none',
   VERBOSE = 'verbose',
 }
+
+export declare type ConnectionToken = string;
+export declare type FetchConnectionTokenFn = () => Promise<ConnectionToken>;
+
 export interface StatusEvent<T extends string> {
   status: T;
 }


### PR DESCRIPTION
### Summary & motivation

It will still require a `ts-ignore` when accessing values because it's an enum, but this will at least provide a signal that the object is on the `StripeTerminal` object.

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
Pulled it into the internal sample app, works
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
