### PR TITLE
adding location and address to exported types

### DIFF
--- a/pure.d.ts
+++ b/pure.d.ts
@@ -1,13 +1,13 @@
 import {loadStripeTerminal as IloadStripeTerminal} from './src/pure';
-import {TerminalProps} from './types/terminal-js/rabbit/terminal-props';
 import {
   Terminal,
   PaymentStatus,
   ConnectionStatus,
   OutputLogLevel,
-} from './types/terminal-js/index';
+  TerminalProps,
+} from './types/terminal';
 
-export * from './types/terminal-js/index';
+export * from './types/terminal';
 
 export interface StripeTerminal {
   create(props: TerminalProps): Terminal;

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/interface-name-prefix: 0 */
 import {
   IActivateTerminalRequest,
   IErrorResponse,
@@ -70,7 +71,6 @@ export declare type TerminalProps = TerminalOptions & TerminalCallbacks;
 
 export declare type PaymentIntentClientSecret = string;
 
-// eslint-disable-next-line
 export interface ISdkManagedPaymentIntent extends IPaymentIntent {
   sdk_payment_details: IPaymentMethod;
 }
@@ -131,6 +131,29 @@ export declare type DiscoveryConfig = InternetMethodConfiguration;
 export declare type DiscoverResult = {
   discoveredReaders: Array<Reader>;
 };
+
+export interface Address {
+  city?: string | null;
+  state?: string | null;
+  postal_code?: string | null;
+  country?: string | null;
+  line2?: string | null;
+}
+
+export interface Location {
+  id?: string | null;
+  display_name?: string | null;
+  address?: Address | null;
+  timezone?: string | null;
+  release_config_id?: string | null;
+  pinpad_config_id?: string | null;
+  is_default?: boolean | null;
+  is_livemode?: boolean | null;
+  livemode?: boolean | null;
+  deleted?: boolean | null;
+  merchant?: string | null;
+  metadata?: {[k: string]: string} | null;
+}
 
 export class Terminal {
   /**

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -133,6 +133,7 @@ export declare type DiscoverResult = {
 };
 
 export interface Address {
+  line1?: string | null;
   city?: string | null;
   state?: string | null;
   postal_code?: string | null;


### PR DESCRIPTION
### Summary & motivation
What it says on the tin. Exporting Location and Address, while not used in any SDK calls currently, with increased location work our users may want type safety for calls they are making in their own implementations.

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
CI passes, 🚢 

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
