### PR TITLE
Reader / Location open api types

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -36,10 +36,16 @@ const main = async () => {
   const reader: {reader: Reader} | ErrorResponse = await terminal.connectReader(
     {
       id: 'id',
-      object: 'object',
-      device_type: 'type',
+      object: 'terminal.reader',
+      device_type: 'verifone_P400',
       ip_address: 'address',
       serial_number: 'serial',
+      livemode: false,
+      device_sw_version: '0.0.0',
+      label: 'foo',
+      location: null,
+      metadata: {},
+      status: 'online',
     }
   );
 

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -105,7 +105,7 @@ export interface SimulatorConfiguration {
   testCardNumber?: string | null;
 }
 
-type DeviceType = 'bbpos_chipper2x' | 'verifone_P400';
+type DeviceType = 'bbpos_wisepos_e' | 'verifone_P400';
 
 export interface Reader {
   id: string;
@@ -142,27 +142,22 @@ export declare type DiscoverResult = {
 };
 
 export interface Address {
-  line1?: string | null;
-  city?: string | null;
-  state?: string | null;
-  postal_code?: string | null;
-  country?: string | null;
-  line2?: string | null;
+  city: string | null;
+  country: string | null;
+  line1: string | null;
+  line2: string | null;
+  postal_code: string | null;
+  state: string | null;
 }
 
 export interface Location {
-  id?: string | null;
-  display_name?: string | null;
-  address?: Address | null;
-  timezone?: string | null;
-  release_config_id?: string | null;
-  pinpad_config_id?: string | null;
-  is_default?: boolean | null;
-  is_livemode?: boolean | null;
-  livemode?: boolean | null;
-  deleted?: boolean | null;
-  merchant?: string | null;
-  metadata?: {[k: string]: string} | null;
+  id: string;
+  object: 'terminal.location';
+  address: Address;
+  deleted?: void;
+  display_name: string;
+  livemode: boolean;
+  metadata: Metadata;
 }
 
 export class Terminal {

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -105,6 +105,8 @@ export interface SimulatorConfiguration {
   testCardNumber?: string | null;
 }
 
+type DeviceType = 'bbpos_chipper2x' | 'verifone_P400';
+
 export interface Reader {
   id: string;
   object: 'terminal.reader';
@@ -119,8 +121,6 @@ export interface Reader {
   serial_number: string;
   status: string | null;
 }
-
-type DeviceType = 'bbpos_chipper2x' | 'verifone_P400';
 
 interface Metadata {
   [name: string]: string;

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -106,17 +106,24 @@ export interface SimulatorConfiguration {
 }
 
 export interface Reader {
-  id?: string | null;
-  object?: string | null;
-  device_sw_version?: string | null;
-  device_type?: string | null;
-  ip_address?: string | null;
-  label?: string | null;
-  location?: string | null;
-  serial_number?: string | null;
-  status?: string | null;
-  livemode?: boolean | null;
-  base_url?: string | null;
+  id: string;
+  object: 'terminal.reader';
+  deleted?: void;
+  device_sw_version: string | null;
+  device_type: DeviceType;
+  ip_address: string | null;
+  label: string;
+  livemode: boolean;
+  location: string | null;
+  metadata: Metadata;
+  serial_number: string;
+  status: string | null;
+}
+
+type DeviceType = 'bbpos_chipper2x' | 'verifone_P400';
+
+interface Metadata {
+  [name: string]: string;
 }
 
 export interface DiscoveryMethodConfiguration {


### PR DESCRIPTION
### Summary & motivation
After poking around a bit more, it makes sense to export types from terminal-js that originate from our OpenAPI spec when possible. While users can do this on their own with https://github.com/stripe/stripe-node it makes sense to just export them from terminal-js for ease. Also we can monkey-patch these as we have to if neccessary.

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
CI passes, 🚢 

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
