### PR TITLE
making node binary paths explicit in yarn targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
   "jsnext:main": "dist/terminal.esm.js",
   "types": "types/index.d.ts",
   "scripts": {
-    "test": "jest",
+    "test": "./node_modules/.bin/jest",
     "test:versions": "./tests/versions/scripts/test.sh",
-    "test:types": "tsc -p ./tests/types && jest --roots '<rootDir>/tests/types'",
-    "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-list-different",
-    "typecheck": "tsc",
+    "test:types": "./node_modules/.bin/tsc -p ./tests/types && ./node_modules/.bin/jest --roots '<rootDir>/tests/types'",
+    "lint": "./node_modules/.bin/eslint '{src,types}/**/*.{ts,js}' && yarn prettier-list-different",
+    "typecheck": "./node_modules/.bin/tsc",
     "build": "yarn clean && yarn rollup -c",
-    "clean": "rimraf dist",
+    "clean": "./node_modules/.bin/rimraf dist",
     "ci": "yarn lint && yarn test && yarn test:versions && yarn test:types && yarn typecheck && yarn build",
     "prepublishOnly": "echo \"\nPlease use ./scripts/publish instead\n\" && exit 1",
-    "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
-    "prettier-list-different": "prettier './**/*.{js,ts,md,html,css}' --list-different"
+    "prettier": "./node_modules/.bin/prettier './**/*.{js,ts,md,html,css}' --write",
+    "prettier-list-different": "./node_modules/.bin/prettier './**/*.{js,ts,md,html,css}' --list-different"
   },
   "keywords": [
     "Stripe",


### PR DESCRIPTION
### Summary & motivation
Had an internal report that type checks weren't working, turned out `tsc` was being pulled from a global bin and not the one in the repo. Updating yarn targets to point explicitly at `./node_modules/.bin/<target>`

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
ran locally, worked 🎉 

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
