### PR TITLE
add ITippingConfig for tip eligible amounts

### DIFF
--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -94,6 +94,14 @@ export interface ICollectConfig {
   // Bypass tipping selection if it would have otherwise been shown.
   // For more information, see the official Stripe docs: [On Reader Tipping](https://stripe.com/docs/terminal/features/collecting-tips/on-reader)
   skip_tipping?: boolean | null;
+  tipping?: ITippingConfig | null;
+}
+
+// Contains per-transaction configuration information relevant to collecting tips
+export interface ITippingConfig {
+  // Calculate percentage-based tips based on this amount.
+  // For more information, see the official Stripe docs: [On Reader Tipping](https://stripe.com/docs/terminal/features/collecting-tips/on-reader)
+  eligible_amount?: number | null;
 }
 
 export declare type ConnectOptions = Pick<


### PR DESCRIPTION
### Summary & motivation

Adding types for `ITippingConfig` for use with tip-eligible amounts feature.

Docs: https://stripe.com/docs/terminal/features/collecting-tips/on-reader#tip-eligible

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
