### PR TITLE
skiplibcheck to fix tsc errors for now

### DIFF
--- a/tests/versions/tsconfig.json
+++ b/tests/versions/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "strict": true,
     "moduleResolution": "node",
-    "types": ["../.."]
+    "types": ["../.."],
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

seems some library types changed in 4.9+, skip checking types for now to fix tsc errors

### Testing & documentation

ran `yarn test:versions` and it passed

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
