### PR TITLE
terminal: Add `tipAmount` to simulator configuration

### DIFF
--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -141,6 +141,7 @@ export interface SimulatorConfiguration {
   paymentMethodType?: 'interac_present' | null;
   testPaymentMethod?: string | null;
   testCardNumber?: string | null;
+  tipAmount?: number | null;
 }
 
 export interface DiscoveryMethodConfiguration {


### PR DESCRIPTION
### Summary & motivation

Allow users to simulate an on-reader tip amount when collecting a
payment via the simulated reader.
