### PR TITLE
Bump package to 0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/terminal-js",
-  "version": "0.14.0",
+  "version": "0.18.0",
   "description": "Stripe Terminal loading utility",
   "main": "dist/terminal.js",
   "module": "dist/terminal.esm.js",


### PR DESCRIPTION
### Summary & motivation
- Package release script skipped some versions, so bumping to the latest released version
