### PR TITLE
Revert reader type to use Stripe API

### DIFF
--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -91,31 +91,9 @@ export declare type TerminalProps = TerminalOptions & TerminalCallbacks;
 
 export declare type PaymentIntentClientSecret = string;
 
-export enum DeviceType {
-  P400 = 'verifone_P400',
-  WISEPOSE = 'bbpos_wisepos_e',
-  S700 = 'stripe_s700',
-}
+export declare type DeviceType = Stripe.Terminal.Reader.DeviceType;
 
-export interface Metadata {
-  [name: string]: string;
-}
-
-export interface Reader {
-  id: string;
-  object: 'terminal.reader';
-  deleted?: void;
-  device_sw_version: string | null;
-  device_type: DeviceType;
-  ip_address: string | null;
-  label: string;
-  livemode: boolean;
-  location: string | null;
-  metadata: Metadata;
-  serial_number: string;
-  status: 'online' | 'offline' | null;
-  base_url?: string | null;
-}
+export declare type Reader = Stripe.Terminal.Reader;
 
 export declare type IPaymentIntent = Stripe.PaymentIntent;
 export declare type ISetupIntent = Stripe.SetupIntent;


### PR DESCRIPTION
### Summary & motivation
I was mistaken about the actual type the SDK uses and turns out Stripe API's type is more accurate. 
<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
