### PR TITLE
Bump version to match latest on npm (0.22.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/terminal-js",
-  "version": "0.19.0",
+  "version": "0.22.0",
   "description": "Stripe Terminal loading utility",
   "main": "dist/terminal.js",
   "module": "dist/terminal.esm.js",


### PR DESCRIPTION
### Summary & motivation

When publishing the latest npm release I ran into issues releasing because the release script was trying to increment 0.19.0 to 0.20.0 (which already exists on npm). This bumps the latest version on master to the latest version on npm so we can release a new version

### Testing & documentation
CI