### PR TITLE
terminal: Add cancel* method definitions

### DIFF
--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -486,6 +486,7 @@ export class Terminal {
         paymentIntent: ISdkManagedPaymentIntent;
       }
   >;
+  cancelCollectPaymentMethod(): Promise<ErrorResponse | ICancelResponse>;
   /**
    * Confirms the payment intent which causes the charging of the user card.
    * @param request Object containing the payment intent to confirm.
@@ -501,7 +502,6 @@ export class Terminal {
         paymentIntent: IPaymentIntent;
       }
   >;
-  cancelCollectPaymentMethod(): Promise<ErrorResponse | ICancelResponse>;
   readReusableCard(options?: {
     customer?: string;
   }): Promise<
@@ -545,6 +545,7 @@ export class Terminal {
     currency: string,
     options?: RefundOptions
   ): Promise<ErrorResponse | ICollectRefundPaymentMethodResponse>;
+  cancelCollectRefundPaymentMethod(): Promise<ErrorResponse | ICancelResponse>;
 
   processRefund(): Promise<
     | ErrorResponse
@@ -554,7 +555,6 @@ export class Terminal {
       }
   >;
 
-  cancelCollectRefundPaymentMethod(): Promise<ErrorResponse | ICancelResponse>;
   cancelReadReusableCard(): Promise<ErrorResponse | ICancelResponse>;
   setSimulatorConfiguration(config: any): void;
   getSimulatorConfiguration(): SimulatorConfiguration;

--- a/types/terminal.d.ts
+++ b/types/terminal.d.ts
@@ -502,6 +502,7 @@ export class Terminal {
         paymentIntent: IPaymentIntent;
       }
   >;
+  cancelProcessPayment(): Promise<ErrorResponse | ICancelResponse>;
   readReusableCard(options?: {
     customer?: string;
   }): Promise<
@@ -538,6 +539,7 @@ export class Terminal {
   confirmSetupIntent(
     setupIntent: ISetupIntent
   ): Promise<ErrorResponse | {setupIntent: ISetupIntent}>;
+  cancelConfirmSetupIntent(): Promise<ErrorResponse | ICancelResponse>;
 
   collectRefundPaymentMethod(
     charge_id: string,
@@ -554,6 +556,7 @@ export class Terminal {
         refund: IRefund;
       }
   >;
+  cancelProcessRefund(): Promise<ErrorResponse | ICancelResponse>;
 
   cancelReadReusableCard(): Promise<ErrorResponse | ICancelResponse>;
   setSimulatorConfiguration(config: any): void;


### PR DESCRIPTION
### Summary & motivation

Add in cancel method definitions on Terminal object.

r? @henryx-stripe
