### PR TITLE
chore: add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,13 @@
   "author": "Stripe (https://www.stripe.com)",
   "license": "MIT",
   "homepage": "https://stripe.com/docs/terminal/sdk/js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stripe/terminal-js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stripe/terminal-js/issues"
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
## Summary
- add standard npm support metadata to `package.json`
- point `repository` to this public GitHub repo
- add `bugs.url` for the issue tracker

## Testing
- `node -e "const p=require('./package.json'); if(p.repository?.type!=='git'||p.repository?.url!=='git+https://github.com/stripe/terminal-js.git'||p.bugs?.url!=='https://github.com/stripe/terminal-js/issues'||p.homepage!=='https://stripe.com/docs/terminal/sdk/js') process.exit(1); console.log(JSON.stringify({homepage:p.homepage,repository:p.repository,bugs:p.bugs}, null, 2))"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
