### PR TITLE
fix: add missing npm metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
   "dependencies": {
     "stripe": "^8.222.0",
     "ws": "6.2.3"
+  },
+  "bugs": {
+    "url": "https://github.com/stripe/terminal-js/issues"
   }
 }


### PR DESCRIPTION
Adds missing npm metadata fields to improve package discoverability.